### PR TITLE
Allow switching between Deployment and StatefulSet controllers

### DIFF
--- a/charts/datahub-executor-worker/Chart.yaml
+++ b/charts/datahub-executor-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub-executor-worker
 description: A Helm chart for datahub-executor-worker
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: 0.0.1
 maintainers:
   - name: DataHub

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: {{ .Values.workloadKind }}
 metadata:
   name: {{ include "datahub-executor-worker.fullname" . }}
   labels:
@@ -13,6 +13,9 @@ spec:
     matchLabels:
       {{- include "datahub-executor-worker.selectorLabels" . | nindent 6 }}
   {{- if .Values.persistentVolume.enabled }}
+  {{- if ne .Values.workloadKind "StatefulSet" }}
+  {{- fail "workloadKind must be set to StatefulSet when persistent volume is enabled" }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         {{- with .Values.persistentVolume.annotations }}

--- a/charts/datahub-executor-worker/values.yaml
+++ b/charts/datahub-executor-worker/values.yaml
@@ -12,6 +12,8 @@ global:
       monitors:
         max_workers: 10
 
+workloadKind: Deployment
+
 replicaCount: 1
 
 revisionHistoryLimit: 1
@@ -93,6 +95,7 @@ readinessProbe:
   timeoutSeconds: 5
 
 persistentVolume:
+  # Requires workloadKind: StatefulSet
   enabled: false
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Default to `Deployment` workload. `StatefulSet` is only required when a persistent volume template is enabled.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
