### PR TITLE
Rename worker_id to executor_id

### DIFF
--- a/charts/datahub-executor-worker/Chart.yaml
+++ b/charts/datahub-executor-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub-executor-worker
 description: A Helm chart for datahub-executor-worker
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: 0.0.1
 maintainers:
   - name: DataHub

--- a/charts/datahub-executor-worker/README.md
+++ b/charts/datahub-executor-worker/README.md
@@ -4,9 +4,9 @@
 # Create secret object with GMS access token. Note that secret name and key must match those in values file
 $ kubectl create secret generic datahub-access-token-secret --from-literal=datahub-access-token-secret-key=<DATAHUB-ACCESS-TOKEN>
 
-# Deploy executor with worker ID "remote" and GMS URL "https://company.acryl.io/gms"
+# Deploy executor with executor ID "remote" and GMS URL "https://company.acryl.io/gms"
 $ helm install \
-  --set global.datahub.executor.worker_id="remote" \
+  --set global.datahub.executor.executor_id="remote" \
   --set global.datahub.gms.url="https://company.acryl.io/gms" \
     default ./charts/datahub-executor-worker
 ```

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -134,8 +134,10 @@ spec:
                   key: {{ ((.Values.global.datahub).gms).secretKey }}
             - name: DATAHUB_EXECUTOR_MODE
               value: "worker"
+            {{- with .Values.global.datahub.executor }}
             - name: DATAHUB_EXECUTOR_WORKER_ID
-              value: {{ .Values.global.datahub.executor.worker_id | quote }}
+              value: {{ .executor_id | default .worker_id | quote }}
+            {{- end }}
             - name: DATAHUB_EXECUTOR_INGESTION_MAX_WORKERS
               value: {{ .Values.global.datahub.executor.ingestions.max_workers | quote }}
             - name: DATAHUB_EXECUTOR_INGESTION_SIGNAL_POLL_INTERVAL

--- a/charts/datahub-executor-worker/values.yaml
+++ b/charts/datahub-executor-worker/values.yaml
@@ -5,7 +5,7 @@ global:
       secretKey: datahub-access-token-secret-key
       url: https://datahub.acryl.io/gms
     executor:
-      worker_id: "remote"
+      executor_id: "remote"
       ingestions:
         max_workers: 4
         signal_poll_interval: 2


### PR DESCRIPTION
To more closely match naming used in DataHub. Both `executor_id` and `worker_id` are supported with `executor_id` taking precedence.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
