### PR TITLE
fix(executor-worker): drop dockerize wrapper, let image CMD run

### DIFF
--- a/charts/datahub-executor-worker/Chart.yaml
+++ b/charts/datahub-executor-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub-executor-worker
 description: A Helm chart for datahub-executor-worker
 type: application
-version: 0.0.40
+version: 0.0.41
 appVersion: 1.0.1
 maintainers:
   - name: DataHub

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -105,7 +105,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ required "image tag is required" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["dockerize", "/start_datahub_executor.sh"]
+          # Image CMD runs /start_datahub_executor.sh directly. The script has
+          # a shell-based wait_for_gms_ready loop (replacing the previous
+          # `dockerize -wait`), so no wrapper binary is needed. Earlier chart
+          # versions used `command: ["dockerize", "/start_datahub_executor.sh"]`
+          # which broke on Wolfi-based images (no `dockerize` binary).
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
## Summary

The chart hardcodes `command: ["dockerize", "/start_datahub_executor.sh"]` on the main worker container. Wolfi-based executor images (introduced by [datahub-fork#9277](https://github.com/acryldata/datahub-fork/pull/9277), shipped via subsequent PRs including [datahub-fork#8856](https://github.com/acryldata/datahub-fork/pull/8856)) **do not ship the `dockerize` binary** — its `-wait` behavior was replaced by an in-image shell loop inside `/start_datahub_executor.sh`.

With the wrapper in place, the worker container fails at start with:

```
error during container init: exec: "dockerize": executable file not found in $PATH
```

Combined with the `dh-system-update` Job's `scale-down-datahub` init container (which runs `kubectl rollout status deploy/dh-datahub-gms` and waits for GMS to be Ready), this deadlocks SaaS upgrades: the pre-upgrade hook waits forever for GMS to be Ready, but GMS can't reach Ready because of the exec failure above.

## Change

Remove the chart-level `command:` override and let the image's CMD (`exec /start_datahub_executor.sh`) run directly.

`start.sh` already implements the GMS-ready wait in shell form (see `wait_for_gms_ready()`), so behavior is preserved for Wolfi images. Legacy images that still ship `dockerize` will simply not be wrapped with it — fine, because their image entrypoint already calls the same start script.

Chart version bumped `0.0.40 → 0.0.41`.

## Verification

`helm template charts/datahub-executor-worker --set image.tag=test --set global.datahub.gms.secretRef=sr --set global.datahub.gms.secretKey=sk | grep -c dockerize` → `0` (was non-zero before).

## Downstream

After release, consumers' `Chart.yaml` `datahub-executor-worker` dependency should bump to `0.0.41`. The shim workaround that some deployments currently carry in their per-worker values (an `extraInitContainers: install-dockerize-shim` that drops a fake `dockerize` script into an `emptyDir` mounted at `/usr/local/bin/dockerize` via subPath) can be deleted.

## Out of scope (separate fix)

The companion env-var contract change (`start.sh` reads `DATAHUB_GMS_HOST/PORT/PROTOCOL`, defaults `datahub-gms:8080`, while the chart only exports `DATAHUB_GMS_URL`) is **not** addressed here — that needs either a chart-side derivation that also handles SaaS URLs with path prefixes (e.g. `https://dev07.acryl.io/gms`), or a `datahub-fork` change to have `start.sh` curl `${DATAHUB_GMS_URL%/}/health` directly. Filing separately.