### PR TITLE
chore: drop dockerize from worker command; bump chart to 0.0.41

### DIFF
--- a/charts/datahub-executor-worker/Chart.yaml
+++ b/charts/datahub-executor-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub-executor-worker
 description: A Helm chart for datahub-executor-worker
 type: application
-version: 0.0.40
+version: 0.0.41
 appVersion: 1.0.1
 maintainers:
   - name: DataHub

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -105,7 +105,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ required "image tag is required" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["dockerize", "/start_datahub_executor.sh"]
+          command: ["/start_datahub_executor.sh"]
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
Align the deployment with executor images that start via /start_datahub_executor.sh without the dockerize wrapper.



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
