### PR TITLE
feat(worker): export GMS host/port/protocol; bump chart to 0.0.42

### DIFF
--- a/charts/datahub-executor-worker/Chart.yaml
+++ b/charts/datahub-executor-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub-executor-worker
 description: A Helm chart for datahub-executor-worker
 type: application
-version: 0.0.41
+version: 0.0.42
 appVersion: 1.0.1
 maintainers:
   - name: DataHub

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -124,15 +124,41 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          {{- /*
+            Derive default GMS host/port/protocol from gms.url so users
+            with a self-contained internal URL (e.g. http://datahub-gms:8080)
+            don't need to set host/port/protocol explicitly. URL-parsing only
+            kicks in when ALL three are unset — touching any of them switches
+            to literal defaults (8080/http/datahub-gms) for the rest, since
+            partial overrides describe an internal Service that may differ
+            from the external `url`.
+          */ -}}
+          {{- $gmsUrl := ((.Values.global.datahub).gms).url | default "" -}}
+          {{- $explicitHost := ((.Values.global.datahub).gms).host -}}
+          {{- $explicitPort := ((.Values.global.datahub).gms).port -}}
+          {{- $explicitProtocol := ((.Values.global.datahub).gms).protocol -}}
+          {{- $defaultHost := "datahub-gms" -}}
+          {{- $defaultPort := 8080 -}}
+          {{- $defaultProtocol := "http" -}}
+          {{- if and $gmsUrl (not (or $explicitHost $explicitPort $explicitProtocol)) -}}
+            {{- $parsed := urlParse $gmsUrl -}}
+            {{- $defaultProtocol = $parsed.scheme | default "http" -}}
+            {{- $hp := splitn ":" 2 ($parsed.host | default "") -}}
+            {{- $defaultHost = index $hp "_0" | default "datahub-gms" -}}
+            {{- $defaultPort = index $hp "_1" | default (eq $defaultProtocol "https" | ternary 443 8080) -}}
+          {{- end -}}
+          {{- $protocol := $explicitProtocol | default $defaultProtocol -}}
+          {{- $host := $explicitHost | default $defaultHost -}}
+          {{- $port := $explicitPort | default $defaultPort }}
           env:
             - name: DATAHUB_GMS_URL
-              value: {{ ((.Values.global.datahub).gms).url }}
+              value: {{ $gmsUrl }}
             - name: DATAHUB_GMS_PROTOCOL
-              value: {{ ((.Values.global.datahub).gms).protocol | default "http" | quote }}
+              value: {{ $protocol | quote }}
             - name: DATAHUB_GMS_HOST
-              value: {{ ((.Values.global.datahub).gms).host | default "datahub-gms" | quote }}
+              value: {{ $host | quote }}
             - name: DATAHUB_GMS_PORT
-              value: {{ ((.Values.global.datahub).gms).port | default 8080 | quote }}
+              value: {{ $port | quote }}
             - name: DATAHUB_GMS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -127,6 +127,12 @@ spec:
           env:
             - name: DATAHUB_GMS_URL
               value: {{ ((.Values.global.datahub).gms).url }}
+            - name: DATAHUB_GMS_PROTOCOL
+              value: {{ ((.Values.global.datahub).gms).protocol | default "http" | quote }}
+            - name: DATAHUB_GMS_HOST
+              value: {{ ((.Values.global.datahub).gms).host | default "datahub-gms" | quote }}
+            - name: DATAHUB_GMS_PORT
+              value: {{ ((.Values.global.datahub).gms).port | default 8080 | quote }}
             - name: DATAHUB_GMS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/datahub-executor-worker/values.yaml
+++ b/charts/datahub-executor-worker/values.yaml
@@ -4,6 +4,14 @@ global:
       secretRef: datahub-access-token-secret
       secretKey: datahub-access-token-secret-key
       url: https://datahub.acryl.io/gms
+      # host/port/protocol are used by the executor image's startup
+      # readiness gate (wait_for_gms_ready). They point to the in-cluster
+      # GMS Service, which may differ from the external `url` above when
+      # the GMS helm release has a non-empty name prefix
+      # (e.g. "dh-datahub-gms" instead of "datahub-gms").
+      host: datahub-gms
+      port: 8080
+      protocol: http
     executor:
       pool_id: "remote"
       channel: "SQS"

--- a/charts/datahub-executor-worker/values.yaml
+++ b/charts/datahub-executor-worker/values.yaml
@@ -5,10 +5,7 @@ global:
       secretKey: datahub-access-token-secret-key
       url: https://datahub.acryl.io/gms
       # host/port/protocol are used by the executor image's startup
-      # readiness gate (wait_for_gms_ready). They point to the in-cluster
-      # GMS Service, which may differ from the external `url` above when
-      # the GMS helm release has a non-empty name prefix
-      # (e.g. "dh-datahub-gms" instead of "datahub-gms").
+      # readiness gate (wait_for_gms_ready).
       host: datahub-gms
       port: 8080
       protocol: http

--- a/charts/datahub-executor-worker/values.yaml
+++ b/charts/datahub-executor-worker/values.yaml
@@ -4,11 +4,6 @@ global:
       secretRef: datahub-access-token-secret
       secretKey: datahub-access-token-secret-key
       url: https://datahub.acryl.io/gms
-      # host/port/protocol are used by the executor image's startup
-      # readiness gate (wait_for_gms_ready).
-      host: datahub-gms
-      port: 8080
-      protocol: http
     executor:
       pool_id: "remote"
       channel: "SQS"


### PR DESCRIPTION
## Summary
Export `DATAHUB_GMS_HOST` / `PORT` / `PROTOCOL` env vars from the `datahub-executor-worker` chart so the executor image's startup readiness gate (`wait_for_gms_ready` in `start.sh`) can find GMS in any deployment, with sensible defaults derived from `gms.url`.

## Problem
The executor image's `wait_for_gms_ready` shell function (the Wolfi-image replacement for `dockerize`) reads `DATAHUB_GMS_HOST` / `PORT` / `PROTOCOL`. The chart only exported `DATAHUB_GMS_URL`. With nothing else set, the gate fell back to a hardcoded `http://datahub-gms:8080/health` and timed out after 240s in any namespace where the actual Service is something like `dh-datahub-gms`.

Observed on `f7700a3ff0-dev07` (pr8856 image, chart 0.0.41): worker pods crashlooping with `Waiting for GMS at http://datahub-gms:8080/health (timeout 240s)...` while the actual Service is `dh-datahub-gms`.

## Behavior
Precedence per field (`host`, `port`, `protocol`):

1. **Any of the three explicitly set in values** → use the explicit values; unset fields fall back to literal internal defaults (`datahub-gms` / `8080` / `http`). The trio is treated as "all-or-nothing" — touching one means the user is describing the internal Service, so other defaults are also internal-friendly. This prevents partial-override silent corruption (e.g., setting `host: dh-datahub-gms` against an external LB URL inheriting `port: 443`).
2. **None of the three set, but `gms.url` is set** → derive all three by parsing the URL (sprig `urlParse`). Self-contained installs (`gms.url: http://datahub-gms:8080`) need no extra config.
3. **Nothing set at all** → literal defaults `datahub-gms` / `8080` / `http` — matches the script's previous hardcoded fallback, preserving backward compatibility with chart 0.0.41.

## Verification

Rendered against 16 edge cases (`helm template` locally), covering:

- Backward compat (no URL, no overrides) — literal defaults preserved
- Self-contained internal URL only — chart parses everything
- External LB URL only — chart parses (probe likely 404s at LB root; documents the case)
- LB URL + partial override (only host set) — port/protocol fall back to internal literals, **not** URL-parsed
- All 3 overrides explicit — exact values pass through
- URL with non-standard port — parsed correctly
- URL with query string / userinfo / path / trailing slash — handled cleanly
- Empty/missing URL — falls to literal defaults
- Each explicit value beats URL parsing — precedence verified

## Companion change
`acryldata/datahub-fork#9666` makes `start.sh` also derive these from `DATAHUB_GMS_URL` as a fallback — defense in depth so future regressions can't recur. That change has merged to `acryl-main`; backport to `releases/v1.1.0` is on branch `cherry-pick/9666-to-releases-v1.1.0`.