### PR TITLE
fix(worker): revert URL-parsing from 0.0.42; bump to 0.0.43

### DIFF
--- a/charts/datahub-executor-worker/Chart.yaml
+++ b/charts/datahub-executor-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub-executor-worker
 description: A Helm chart for datahub-executor-worker
 type: application
-version: 0.0.42
+version: 0.0.43
 appVersion: 1.0.1
 maintainers:
   - name: DataHub

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -124,41 +124,9 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          {{- /*
-            Derive default GMS host/port/protocol from gms.url so users
-            with a self-contained internal URL (e.g. http://datahub-gms:8080)
-            don't need to set host/port/protocol explicitly. URL-parsing only
-            kicks in when ALL three are unset — touching any of them switches
-            to literal defaults (8080/http/datahub-gms) for the rest, since
-            partial overrides describe an internal Service that may differ
-            from the external `url`.
-          */ -}}
-          {{- $gmsUrl := ((.Values.global.datahub).gms).url | default "" -}}
-          {{- $explicitHost := ((.Values.global.datahub).gms).host -}}
-          {{- $explicitPort := ((.Values.global.datahub).gms).port -}}
-          {{- $explicitProtocol := ((.Values.global.datahub).gms).protocol -}}
-          {{- $defaultHost := "datahub-gms" -}}
-          {{- $defaultPort := 8080 -}}
-          {{- $defaultProtocol := "http" -}}
-          {{- if and $gmsUrl (not (or $explicitHost $explicitPort $explicitProtocol)) -}}
-            {{- $parsed := urlParse $gmsUrl -}}
-            {{- $defaultProtocol = $parsed.scheme | default "http" -}}
-            {{- $hp := splitn ":" 2 ($parsed.host | default "") -}}
-            {{- $defaultHost = index $hp "_0" | default "datahub-gms" -}}
-            {{- $defaultPort = index $hp "_1" | default (eq $defaultProtocol "https" | ternary 443 8080) -}}
-          {{- end -}}
-          {{- $protocol := $explicitProtocol | default $defaultProtocol -}}
-          {{- $host := $explicitHost | default $defaultHost -}}
-          {{- $port := $explicitPort | default $defaultPort }}
           env:
             - name: DATAHUB_GMS_URL
-              value: {{ $gmsUrl }}
-            - name: DATAHUB_GMS_PROTOCOL
-              value: {{ $protocol | quote }}
-            - name: DATAHUB_GMS_HOST
-              value: {{ $host | quote }}
-            - name: DATAHUB_GMS_PORT
-              value: {{ $port | quote }}
+              value: {{ ((.Values.global.datahub).gms).url }}
             - name: DATAHUB_GMS_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
Revert the URL-parsing logic introduced in [#70](https://github.com/acryldata/datahub-executor-helm/pull/70) (chart 0.0.42). Chart 0.0.43 is functionally identical to 0.0.41 — only emits `DATAHUB_GMS_URL`. The proper fix for the original problem lives in the image, not the chart.

## What 0.0.42 broke
PR #70 made the chart auto-derive and unconditionally export `DATAHUB_GMS_HOST` / `PORT` / `PROTOCOL` from `gms.url`. This broke the DataHub Python SDK in deployments with a path-prefixed URL.

The SDK's [`_get_config_from_env()`](https://github.com/acryldata/datahub-fork/blob/f1c95c79d165140f30be8e706cdae19d99940b27/metadata-ingestion/src/datahub/cli/config_utils.py#L78-L93) has this branch:

```python
if port is not None:
    url = f"{protocol}://{host}:{port}"   # <-- URL discarded, path lost
    return url, token
```

For `gms.url: https://dev07.acryl.io/gms`, the chart exported `PORT=443`, triggering this branch. The SDK reconstructed `https://dev07.acryl.io:443` — losing the `/gms` path — which hit the frontend, not GMS. 

## Why we don't need the env vars at all

The original motivation for setting `DATAHUB_GMS_HOST/PORT/PROTOCOL` in chart 0.0.42 was to feed the image's `wait_for_gms_ready` startup readiness gate, which (in pr8856 / v1.1.0rc1) hardcoded `datahub-gms` as the host and failed DNS in namespaces with a Helm release prefix (e.g. `dh-datahub-gms`).

That bug has now been fixed at the image level:
- [acryldata/datahub-fork#9666](https://github.com/acryldata/datahub-fork/pull/9666) — `start.sh` now reads `DATAHUB_GMS_URL` directly. (Merged to `acryl-main`.)
- [acryldata/datahub-fork#9668](https://github.com/acryldata/datahub-fork/pull/9668) — backport to `releases/v1.1.0`. (Merged.)

Once the worker image carries that script change, both consumers in the pod (the startup script and the Python SDK) read `DATAHUB_GMS_URL` directly and need no other env vars. Exposing `host/port/protocol` in the chart adds surface area without functional benefit — and, as we just discovered, can actively break things.

## What this PR does
- Reverts `templates/workload.yaml` to the 0.0.41 env block (only `DATAHUB_GMS_URL` is emitted).
- Bumps chart version `0.0.42` → `0.0.43`.


## Verified
`helm template` with default values → only `DATAHUB_GMS_URL` exported.
`helm template` with `gms.host=...` override → still only `DATAHUB_GMS_URL` exported (the override is ignored).