### PR TITLE
feat: optional OAuth auth for the remote executor worker

### DIFF
--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -127,7 +127,7 @@ spec:
           env:
             - name: DATAHUB_GMS_URL
               value: {{ ((.Values.global.datahub).gms).url }}
-            {{- if ((.Values.global.datahub).gms).secretRef }}
+            {{- if and (((.Values.global.datahub).gms).secretRef) (not (((.Values.global).datahub).auth).type) }}
             - name: DATAHUB_GMS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -127,11 +127,37 @@ spec:
           env:
             - name: DATAHUB_GMS_URL
               value: {{ ((.Values.global.datahub).gms).url }}
+            {{- if ((.Values.global.datahub).gms).secretRef }}
             - name: DATAHUB_GMS_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ ((.Values.global.datahub).gms).secretRef }}
                   key: {{ ((.Values.global.datahub).gms).secretKey }}
+            {{- end }}
+            {{- with (((.Values.global).datahub).auth) }}
+            {{- if .type }}
+            - name: DATAHUB_AUTH_TYPE
+              value: {{ .type | quote }}
+            {{- if eq .type "k8s_oidc" }}
+            - name: DATAHUB_AUTH_TOKEN_FILE
+              value: {{ .tokenFile | quote }}
+            - name: DATAHUB_AUTH_AUDIENCE
+              value: {{ .audience | quote }}
+            {{- else if eq .type "azure_entra" }}
+            - name: DATAHUB_AUTH_AZURE_TENANT_ID
+              value: {{ .azure.tenantId | quote }}
+            - name: DATAHUB_AUTH_AZURE_CLIENT_ID
+              value: {{ .azure.clientId | quote }}
+            - name: DATAHUB_AUTH_AZURE_SCOPE
+              value: {{ .azure.scope | quote }}
+            {{- else if eq .type "oidc_client_credentials" }}
+            - name: DATAHUB_AUTH_TOKEN_ENDPOINT
+              value: {{ .oidc.tokenEndpoint | quote }}
+            - name: DATAHUB_AUTH_CLIENT_ID
+              value: {{ .oidc.clientId | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             - name: DATAHUB_EXECUTOR_MODE
               value: {{ eq (.Values.global.datahub.executor.channel | default "SQS") "KAFKA" | ternary "kafka-worker" "worker" | quote }}
             - name: DATAHUB_EXECUTOR_POOL_ID

--- a/charts/datahub-executor-worker/values.yaml
+++ b/charts/datahub-executor-worker/values.yaml
@@ -1,9 +1,22 @@
 global:
   datahub:
     gms:
-      secretRef: datahub-access-token-secret
+      secretRef: datahub-access-token-secret  # set to "" for OAuth (DATAHUB_AUTH_TYPE) deployments
       secretKey: datahub-access-token-secret-key
       url: https://datahub.acryl.io/gms
+    auth:
+      type: ""  # "" = PAT/system; k8s_oidc | azure_entra | oidc_client_credentials
+      tokenFile: ""  # k8s_oidc: path to the projected service-account token
+      audience: ""  # k8s_oidc / oidc_client_credentials: token audience
+      azure:
+        tenantId: ""
+        clientId: ""
+        scope: ""
+      oidc:
+        tokenEndpoint: ""
+        clientId: ""
+      # Client secrets (DATAHUB_AUTH_CLIENT_SECRET, DATAHUB_AUTH_AZURE_CLIENT_SECRET)
+      # come from extraEnvsFrom (referencing a Secret), not plaintext values here.
     executor:
       pool_id: "remote"
       channel: "SQS"


### PR DESCRIPTION
## Summary

Adds optional OAuth authentication to the remote executor worker chart, the companion to the executor-side OAuth work.

- `DATAHUB_GMS_TOKEN` is now rendered **conditionally** — only when a PAT secret is configured **and** no OAuth `auth.type` is set (so `auth.type` is the dominant switch and PAT/OAuth can never both render).
- New first-class `global.datahub.auth.*` values render the `DATAHUB_AUTH_*` env vars for `k8s_oidc` / `azure_entra` / `oidc_client_credentials`.
- Client secrets and projected service-account tokens ride the chart's existing `extraEnvs` / `extraEnvsFrom` (ConfigMap) / `extraVolumes` / `serviceAccount.annotations` extension points — no plaintext secret values in chart values.

## Backward compatibility

Fully preserved. The default `secretRef` is unchanged, so an existing PAT install renders `DATAHUB_GMS_TOKEN` exactly as before; `auth.type` does nothing until the executor image that consumes it ships. OAuth-only users set `secretRef: ""` and an `auth.type`.

## Verification

`helm lint` clean; `helm template` confirmed across four modes — default (PAT only), `k8s_oidc`, `azure_entra`, `oidc_client_credentials` — and the dual-set regression (default secretRef + `auth.type`) renders the auth env and **no** `DATAHUB_GMS_TOKEN`.

## Why Draft

Pairs with the executor OAuth PR in `datahub-fork`; holding until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
