### PR TITLE
ci: add sync reminder workflow for Terraform and CloudFormation

### DIFF
--- a/.github/workflows/sync-reminder.yaml
+++ b/.github/workflows/sync-reminder.yaml
@@ -21,7 +21,9 @@ jobs:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
       LINEAR_TEAM_ID: b1c9a278-522e-47cb-81af-8b860ead0c76
       LINEAR_TODO_STATE_ID: ef7a0a27-3272-4bfc-ad93-0ad9dd25bba5
-      LINEAR_PROJECT_ID: ''
+      LINEAR_PROJECT_ID: c35ebf0c-d99d-4e7a-9d01-1962839bcc22
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: C05SL1JUD6F
     steps:
       - name: Resolve PR Author Email
         id: author-email
@@ -186,3 +188,36 @@ jobs:
             await github.rest.issues.createComment({
               owner, repo, issue_number: pr.number, body,
             });
+
+      - name: Notify Ingestion Slack If Unassigned
+        if: steps.assignee.outputs.assignee_id == '' && env.SLACK_BOT_TOKEN != ''
+        uses: actions/github-script@v7
+        env:
+          ISSUE_IDENTIFIER: ${{ steps.ticket.outputs.issue_identifier }}
+          ISSUE_URL: ${{ steps.ticket.outputs.issue_url }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const id = process.env.ISSUE_IDENTIFIER;
+            const url = process.env.ISSUE_URL;
+            const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            const text = [
+              `:arrows_counterclockwise: *Remote Executor sync ticket needs an owner* — <${url}|${id}>`,
+              `Merged PR <${pr.html_url}|#${pr.number}> ("${esc(pr.title)}") by \`${author}\` couldn't be auto-assigned in Linear (no matching user).`,
+              "Please pick it up, or close the ticket if the change doesn't affect Terraform / CloudFormation.",
+            ].join('\n');
+            const res = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+                'Content-Type': 'application/json; charset=utf-8',
+              },
+              body: JSON.stringify({ channel: process.env.SLACK_CHANNEL_ID, text }),
+            });
+            // Slack returns HTTP 200 even on logical errors; check the ok field.
+            const json = await res.json();
+            if (!json.ok) {
+              throw new Error(`Slack chat.postMessage failed: ${json.error}`);
+            }
+            core.info('Posted unassigned-ticket notification to #ingestion-pod.');

--- a/.github/workflows/sync-reminder.yaml
+++ b/.github/workflows/sync-reminder.yaml
@@ -1,0 +1,188 @@
+name: Sync Reminder for Terraform and CloudFormation
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'charts/datahub-executor-worker/templates/**'
+      - 'charts/datahub-executor-worker/values.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  create-sync-ticket:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      LINEAR_TEAM_ID: b1c9a278-522e-47cb-81af-8b860ead0c76
+      LINEAR_TODO_STATE_ID: ef7a0a27-3272-4bfc-ad93-0ad9dd25bba5
+      LINEAR_PROJECT_ID: ''
+    steps:
+      - name: Resolve PR Author Email
+        id: author-email
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (pr.user.type === 'Bot') {
+              core.info('PR author is a bot; skipping email resolution.');
+              core.setOutput('author_email', '');
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const isReal = (e) => e && !e.endsWith('users.noreply.github.com');
+            let email = commits.find(
+              (c) => c.author && c.author.login === pr.user.login && isReal(c.commit.author.email)
+            )?.commit.author.email;
+            if (!email) {
+              email = [...commits].reverse().find((c) => isReal(c.commit?.author?.email))
+                ?.commit.author.email;
+            }
+            core.info(email ? `Resolved author email: ${email}` : 'No usable author email found.');
+            core.setOutput('author_email', email || '');
+
+      - name: Resolve Linear Assignee
+        id: assignee
+        uses: actions/github-script@v7
+        env:
+          AUTHOR_EMAIL: ${{ steps.author-email.outputs.author_email }}
+        with:
+          script: |
+            const email = process.env.AUTHOR_EMAIL;
+            if (!email) {
+              core.info('No author email; ticket will be unassigned.');
+              core.setOutput('assignee_id', '');
+              return;
+            }
+            const res = await fetch('https://api.linear.app/graphql', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': process.env.LINEAR_API_KEY,
+              },
+              body: JSON.stringify({
+                query: 'query($email: String!) { users(filter: { email: { eq: $email } }) { nodes { id displayName } } }',
+                variables: { email },
+              }),
+            });
+            const json = await res.json();
+            if (json.errors) throw new Error('Linear API error: ' + JSON.stringify(json.errors));
+            const user = json.data.users.nodes[0];
+            core.info(user ? `Matched Linear user: ${user.displayName}` : `No Linear user for ${email}.`);
+            core.setOutput('assignee_id', user?.id || '');
+
+      - name: Collect Changed Chart Files
+        id: files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const chartFiles = files
+              .map((f) => f.filename)
+              .filter((f) => f.startsWith('charts/datahub-executor-worker/'))
+              .map((f) => '- `' + f + '`')
+              .join('\n');
+            core.setOutput('chart_files', chartFiles || '_(none detected)_');
+
+      - name: Create Linear Sync Ticket
+        id: ticket
+        uses: actions/github-script@v7
+        env:
+          ASSIGNEE_ID: ${{ steps.assignee.outputs.assignee_id }}
+          CHART_FILES: ${{ steps.files.outputs.chart_files }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const assigneeId = process.env.ASSIGNEE_ID;
+
+            const description = [
+              '### 🔁 Remote Executor deployment sync needed',
+              '',
+              'A PR was merged in the Helm chart (`datahub-executor-worker`) that may need mirroring into the **Terraform** and **CloudFormation** deployment paths.',
+              '',
+              `**Merged PR:** [${pr.title} (#${pr.number})](${pr.html_url})`,
+              `**Author:** @${author}`,
+              '',
+              '**Changed chart files:**',
+              process.env.CHART_FILES,
+              '',
+              '---',
+              '',
+              'Please mirror the change (if applicable) into both other deployment methods:',
+              '',
+              '- [ ] **Terraform** — `acryldata/datahub-terraform-modules` → `remote-ingestion-executor/`',
+              '- [ ] **CloudFormation** — `acryldata/datahub-cloudformation` → `remote-executor/datahub-executor.ecs.template.yaml`',
+              '',
+              "If this change does not affect the container's environment variables / deployment surface, you can mark this ticket **Done** without any further steps.",
+              '',
+              '_Auto-created by the `datahub-executor-helm` sync-reminder workflow._',
+            ].join('\n');
+
+            const input = {
+              teamId: process.env.LINEAR_TEAM_ID,
+              stateId: process.env.LINEAR_TODO_STATE_ID,
+              title: `Sync RE deployment: mirror "${pr.title}" (#${pr.number}) into Terraform & CloudFormation`,
+              description,
+            };
+            if (assigneeId) input.assigneeId = assigneeId;
+            if (process.env.LINEAR_PROJECT_ID) input.projectId = process.env.LINEAR_PROJECT_ID;
+
+            const res = await fetch('https://api.linear.app/graphql', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': process.env.LINEAR_API_KEY,
+              },
+              body: JSON.stringify({
+                query: 'mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { identifier url } } }',
+                variables: { input },
+              }),
+            });
+            const json = await res.json();
+            if (json.errors) throw new Error('Linear API error: ' + JSON.stringify(json.errors));
+            const issue = json.data.issueCreate.issue;
+            core.info(`Created Linear issue ${issue.identifier}: ${issue.url}`);
+            core.setOutput('issue_identifier', issue.identifier);
+            core.setOutput('issue_url', issue.url);
+
+      - name: Comment On PR
+        uses: actions/github-script@v7
+        env:
+          ASSIGNEE_ID: ${{ steps.assignee.outputs.assignee_id }}
+          ISSUE_IDENTIFIER: ${{ steps.ticket.outputs.issue_identifier }}
+          ISSUE_URL: ${{ steps.ticket.outputs.issue_url }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const author = pr.user.login;
+            const id = process.env.ISSUE_IDENTIFIER;
+            const url = process.env.ISSUE_URL;
+            const assigned = process.env.ASSIGNEE_ID !== '';
+
+            const line = assigned
+              ? `@${author} — you've been assigned. Please mirror the change into Terraform and CloudFormation, or close the ticket if it doesn't apply.`
+              : `@${author} — couldn't auto-assign you in Linear; please self-assign **[${id}](${url})**. Mirror the change into Terraform and CloudFormation, or close the ticket if it doesn't apply.`;
+
+            const body = [
+              `🔁 Created a sync reminder to mirror this change into **Terraform** and **CloudFormation**: **[${id}](${url})**`,
+              '',
+              line,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: pr.number, body,
+            });

--- a/.github/workflows/sync-reminder.yaml
+++ b/.github/workflows/sync-reminder.yaml
@@ -12,10 +12,55 @@ permissions:
   pull-requests: write
 
 jobs:
-  create-sync-ticket:
+  evaluate:
     if: >-
       github.event.pull_request.merged == true &&
       github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      should_create: ${{ steps.gate.outputs.should_create }}
+    steps:
+      - name: Determine If Sync Is Needed
+        id: gate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const prefix = 'charts/datahub-executor-worker/';
+            // Chart.yaml is pure version metadata; ignore it when deciding.
+            const relevant = files.filter(
+              (f) => f.filename.startsWith(prefix) && !f.filename.endsWith('/Chart.yaml')
+            );
+            // Any changed chart file other than values.yaml (a template, or anything
+            // unexpected) is a real change. Only values.yaml gets the tag-line check.
+            const nonValues = relevant.filter((f) => !f.filename.endsWith('/values.yaml'));
+            const values = relevant.find((f) => f.filename.endsWith('/values.yaml'));
+            let valuesMeaningful = false;
+            if (values && values.patch) {
+              // A version bump only rewrites the "  tag: vX.Y.Z-cloud" line.
+              const changed = values.patch.split('\n').filter(
+                (l) => (l.startsWith('+') || l.startsWith('-')) &&
+                       !l.startsWith('+++') && !l.startsWith('---')
+              );
+              valuesMeaningful = changed.some((l) => !/^[+-]\s*tag:\s*/.test(l));
+            } else if (values) {
+              // No patch available (e.g. diff too large); fail open and create.
+              valuesMeaningful = true;
+            }
+            const shouldCreate = nonValues.length > 0 || valuesMeaningful;
+            core.info(`nonValuesChanged=${nonValues.length > 0} valuesMeaningful=${valuesMeaningful} should_create=${shouldCreate}`);
+            if (!shouldCreate) {
+              core.info('Version-bump-only change detected; skipping sync ticket.');
+            }
+            core.setOutput('should_create', String(shouldCreate));
+
+  create-sync-ticket:
+    needs: evaluate
+    if: needs.evaluate.outputs.should_create == 'true'
     runs-on: ubuntu-latest
     env:
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
## Summary

The `datahub-executor-worker` Helm chart is the primary deployment path for the remote executor and is where new flags land first. The **Terraform** ([datahub-terraform-modules](https://github.com/acryldata/datahub-terraform-modules) → `remote-ingestion-executor/`) and **CloudFormation** ([datahub-cloudformation](https://github.com/acryldata/datahub-cloudformation) → `remote-executor/`) deployment paths have to be kept in sync by hand — and historically drift (which is why both recently needed Kafka-channel/pool-id reconciliation).

This adds a GitHub Actions workflow that turns "remember to mirror this" into an automatic reminder with a tracked ticket.

## What it does

When a PR that touches `charts/datahub-executor-worker/templates/**` or `values.yaml` is **merged**, the workflow:

1. **Resolves the author** — finds the PR author's git commit email (skips `noreply` aliases and bots).
2. **Best-effort assigns** — matches that email to a Linear user; falls back to unassigned if there's no match.
3. **Creates a Linear ticket** in the **Ingestion Pod** (Todo state) with the PR link, changed chart files, and a **Terraform / CloudFormation checklist**.
4. **Comments on the merged PR** linking the ticket and `@`-mentioning the author (the guaranteed reminder, independent of Linear assignment).

The assignee can **mark the ticket Done without any steps** if the change doesn't affect the deployment surface.

## Design notes

- **Five small `actions/github-script` steps** (resolve email → resolve assignee → collect files → create ticket → comment), each its own log group for easy debugging. Data flows between them via step outputs.
- **Security:** uses `pull_request` (not `pull_request_target`) and an `if` guard skipping fork PRs, so the `LINEAR_API_KEY` secret is never available to untrusted forks. No `checkout`, and no `${{ }}` interpolation of PR-controlled text into scripts (no injection surface).
- **Path-filtered** so version-bump / README-only PRs don't create noise.

## Tested

Each step was validated against live APIs before opening this PR: Linear auth, user-lookup query (known + unknown email), `issueCreate` (a real test ticket was created in the Ingestion Pod and then deleted), and Steps 1/3 logic run against real PR #67 data. All correct.

## ⚠️ Required before this works

Add a **`LINEAR_API_KEY`** repository secret (a Linear personal API key):
```
gh secret set LINEAR_API_KEY --repo acryldata/datahub-executor-helm
```

## Known trade-off

Auto-assignment is best-effort: engineers who commit with a personal/`noreply` email that doesn't match their Linear account will get an **unassigned** ticket (still `@`-mentioned on the PR). If we want higher assignment hit-rate later, a small `github-username → linear-email` override file is a clean follow-up.

Relates to ING-3002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)