### PR TITLE
feat(executor-worker): add Observe/Assertion/Monitor executor flags

### DIFF
--- a/charts/datahub-executor-worker/Chart.yaml
+++ b/charts/datahub-executor-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub-executor-worker
 description: A Helm chart for datahub-executor-worker
 type: application
-version: 0.0.54
+version: 0.0.55
 appVersion: 2.0.5
 maintainers:
   - name: DataHub

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -144,6 +144,26 @@ spec:
               value: {{ .Values.global.datahub.executor.ingestions.signal_poll_interval | quote }}
             - name: DATAHUB_EXECUTOR_MONITORS_MAX_WORKERS
               value: {{ .Values.global.datahub.executor.monitors.max_workers | quote }}
+            - name: ONLINE_SMART_ASSERTIONS_ENABLED
+              value: {{ (((.Values.global.datahub).observability).online_smart_assertions).enabled | default true | quote }}
+            - name: DATAHUB_USE_OBSERVE_MODELS
+              value: {{ (((.Values.global.datahub).observability).inference).use_observe_models | default true | quote }}
+            - name: DATAHUB_USE_INFERENCE_V2
+              value: {{ (((.Values.global.datahub).observability).inference).use_inference_v2 | default false | quote }}
+            - name: DATAHUB_EXECUTOR_ENABLE_DELTA_BOUNDS
+              value: {{ (((.Values.global.datahub).observability).inference).enable_delta_bounds | default true | quote }}
+            - name: DATAHUB_EXECUTOR_ALLOW_CALL_STATEMENTS
+              value: {{ ((.Values.global.datahub).executor).allow_call_statements | default false | quote }}
+            - name: DATAHUB_EXECUTOR_SNOWFLAKE_QUOTE_COLUMNS
+              value: {{ (((.Values.global.datahub).executor).snowflake).quote_columns | default false | quote }}
+            - name: DATAHUB_EXECUTOR_SNOWFLAKE_TIMEOUT
+              value: {{ (((.Values.global.datahub).executor).snowflake).timeout | default 600 | quote }}
+            - name: DATAHUB_EXECUTOR_BIGQUERY_TIMEOUT
+              value: {{ (((.Values.global.datahub).executor).bigquery).timeout | default 600 | quote }}
+            - name: DATAHUB_EXECUTOR_REDSHIFT_TIMEOUT
+              value: {{ (((.Values.global.datahub).executor).redshift).timeout | default 600 | quote }}
+            - name: DATAHUB_EXECUTOR_DATABRICKS_TIMEOUT
+              value: {{ (((.Values.global.datahub).executor).databricks).timeout | default 600 | quote }}
           {{- if .Values.extraEnvs -}}
             {{ toYaml .Values.extraEnvs | nindent 12 }}
           {{- end }}

--- a/charts/datahub-executor-worker/values.yaml
+++ b/charts/datahub-executor-worker/values.yaml
@@ -7,11 +7,40 @@ global:
     executor:
       pool_id: "remote"
       channel: "SQS"
+      # Allow stored-procedure CALL statements in custom SQL assertions. Off by default:
+      # enabling accepts the risk that the procedure body (opaque to SELECT-only sanitization)
+      # may perform mutations.
+      allow_call_statements: false
       ingestions:
         max_workers: 4
         signal_poll_interval: 2
       monitors:
         max_workers: 10
+      # Per-platform statement timeouts (seconds) for the queries the worker issues during
+      # assertion/monitor evaluation.
+      snowflake:
+        timeout: 600
+        # Quote column identifiers in generated Snowflake assertion queries.
+        quote_columns: false
+      bigquery:
+        timeout: 600
+      redshift:
+        timeout: 600
+      databricks:
+        timeout: 600
+    # Smart-assertion / observe feature flags consumed by the executor worker's monitor-training
+    # and assertion-evaluation paths. Defaults mirror the platform (datahub-helm-fork) so remote
+    # executors behave identically. use_observe_models / use_inference_v2 are no-ops on slim
+    # images that do not ship the datahub_observe package.
+    observability:
+      online_smart_assertions:
+        enabled: true
+      inference:
+        use_observe_models: true
+        use_inference_v2: false
+        # Emit delta-space prediction bounds. Set false for executor workers not yet on
+        # delta-aware code, otherwise they may emit false-positive anomalies.
+        enable_delta_bounds: true
 
 workloadKind: Deployment
 


### PR DESCRIPTION
## Summary

Remote executors run monitor training and assertion evaluation, but this chart never set the
Observe/Assertion/Monitor feature flags and per-platform query timeouts that `datahub-helm-fork`
configures for the internal worker. As a result RE behavior could diverge from the platform, and
RE customers (who are slow to update their images) had no way to force these values regardless of
image defaults.

This pins the **10 worker-effective flags**, with defaults mirroring the application-code /
platform defaults:

| Env var | Default |
|---|---|
| `ONLINE_SMART_ASSERTIONS_ENABLED` | `true` |
| `DATAHUB_USE_OBSERVE_MODELS` | `true` |
| `DATAHUB_USE_INFERENCE_V2` | `false` |
| `DATAHUB_EXECUTOR_ENABLE_DELTA_BOUNDS` | `true` |
| `DATAHUB_EXECUTOR_ALLOW_CALL_STATEMENTS` | `false` |
| `DATAHUB_EXECUTOR_SNOWFLAKE_QUOTE_COLUMNS` | `false` |
| `DATAHUB_EXECUTOR_SNOWFLAKE_TIMEOUT` | `600` |
| `DATAHUB_EXECUTOR_BIGQUERY_TIMEOUT` | `600` |
| `DATAHUB_EXECUTOR_REDSHIFT_TIMEOUT` | `600` |
| `DATAHUB_EXECUTOR_DATABRICKS_TIMEOUT` | `600` |

Values are exposed under `global.datahub.executor.*` and `global.datahub.observability.*` and
wired into the container `Environment`. Chart version bumped `0.0.54 → 0.0.55`.

**Scope notes** (verified against the `datahub-executor` source):
- **GMS-only flags** (`TIMESERIES_BUCKETING_ENABLED`, `ASSERTION_MONITORING_RULES_ENABLED`, …)
  are intentionally excluded — they are read by GMS, not the executor worker.
- **`DATAHUB_EXECUTOR_MONITOR_BOOTSTRAP_ENABLED`** is intentionally excluded — it is read only by
  the coordinator's scheduler; the worker builds `MonitorBootstrapExecutor` unconditionally and
  never reads the flag.
- `use_observe_models` / `use_inference_v2` are no-ops on slim images without the
  `datahub_observe` package.

Companion changes: `datahub-terraform-modules` and `datahub-cloudformation` (same flags), and
`datahub-helm-fork` #1154 (internal-worker timeout wiring).

## Checklist
- [x] The PR conforms to DataHub's Contributing Guideline (Commit Message Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016hpMNMv3CnTgYqWfoYDQWk)_