### PR TITLE
feat: Use uv hardlinking to prevent storage expansion

### DIFF
--- a/charts/datahub-executor-worker/Chart.yaml
+++ b/charts/datahub-executor-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub-executor-worker
 description: A Helm chart for datahub-executor-worker
 type: application
-version: 0.0.58
+version: 0.0.59
 appVersion: 2.1.1
 maintainers:
   - name: DataHub

--- a/charts/datahub-executor-worker/templates/workload.yaml
+++ b/charts/datahub-executor-worker/templates/workload.yaml
@@ -164,6 +164,8 @@ spec:
               value: {{ (((.Values.global.datahub).executor).redshift).timeout | default 600 | quote }}
             - name: DATAHUB_EXECUTOR_DATABRICKS_TIMEOUT
               value: {{ (((.Values.global.datahub).executor).databricks).timeout | default 600 | quote }}
+            - name: UV_LINK_MODE
+              value: {{ ((.Values.global.datahub).executor).uv_link_mode | default "hardlink" | quote }}
           {{- if .Values.extraEnvs -}}
             {{ toYaml .Values.extraEnvs | nindent 12 }}
           {{- end }}

--- a/charts/datahub-executor-worker/values.yaml
+++ b/charts/datahub-executor-worker/values.yaml
@@ -7,6 +7,11 @@ global:
     executor:
       pool_id: "remote"
       channel: "SQS"
+      # uv link mode for building ingestion venvs. "hardlink" (default) shares package bytes with
+      # the uv cache — no per-venv copy, no ephemeral spike — and requires the venv working dir and
+      # ~/.cache/uv on the same filesystem. Use "copy" only when they are split (e.g. a separate
+      # emptyDir/tmpfs for /tmp), where hardlinks are impossible.
+      uv_link_mode: hardlink
       # Allow stored-procedure CALL statements in custom SQL assertions. Off by default:
       # enabling accepts the risk that the procedure body (opaque to SELECT-only sanitization)
       # may perform mutations.


### PR DESCRIPTION
In k8s, unlike local docker, UV_LINK_MODE defaults to clone->copy instead of hardlink, therefor causing huge spikes of storage consumption whenever an ingestion is started. On average it can take 400 MB storage for a new venv in copy mode, compared with 50 MB (.pyc files only) in hardlink. This was one of the causes of disk pressure-based evictions of the executor pods.